### PR TITLE
add option to append hash to filename rather than replace it

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -12,6 +12,18 @@ export default assets;
 "
 `;
 
+exports[`Assets with hash appeneded 1`] = `
+"import _fXQovA from './font_fXQovA.woff';
+import _XDOPW from './image_XDOPW.png';
+import _dnIKKh from './blank_dnIKKh.gif';
+import _iQCqkl from './css-font_iQCqkl.css';
+
+var assets = \`\${_fXQovA}|\${_XDOPW}|\${_dnIKKh}|\${_iQCqkl}\`;
+
+export default assets;
+"
+`;
+
 exports[`Mixed Assets 1`] = `
 "import _fXQovA from './fXQovA.woff';
 import _dBNImC from './dBNImC.svg';

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -12,9 +12,9 @@ const readFile = denodeify(fs.readFile)
 
 const outputFolder = "./__tests__/output/"
 
-function bundle(input, outputFile) {
+function bundle(input, outputFile, pluginOptions = {}) {
   var outputFolder = dirname(outputFile)
-  var plugin = rebasePlugin({ outputFolder, input })
+  var plugin = rebasePlugin({ outputFolder, input, ...pluginOptions })
 
   return rollup({
     input,
@@ -141,6 +141,39 @@ test("Mixed Assets", () => {
       rimrafp(outputFile),
       rimrafp(fontFile),
       rimrafp(svgFile),
+      rimrafp(deepFile),
+      rimrafp(cssFile),
+      rimrafp(cssFont)
+    ]))
+})
+
+test("Assets with hash appeneded", () => {
+  var outputFile = `${outputFolder}/assets-hash-appened/index.js`
+
+  var imageFile = `${outputFolder}/assets-hash-appened/image_XDOPW.png`
+  var fontFile = `${outputFolder}/assets-hash-appened/font_fXQovA.woff`
+  var deepFile = `${outputFolder}/assets-hash-appened/blank_dnIKKh.gif`
+  var cssFile = `${outputFolder}/assets-hash-appened/css-font_iQCqkl.css`
+  var cssFont = `${outputFolder}/assets-hash-appened/css-font_gadyfD.woff`
+
+  return bundle("./__tests__/fixtures/assets.js", outputFile, {prependName: true})
+    .then(() =>
+      Promise.all([
+        expect(fileExists(outputFile)).resolves.toBeTruthy(),
+        readFile(outputFile, "utf-8").then((content) => {
+          expect(content).toMatchSnapshot()
+        }),
+        expect(fileExists(imageFile)).resolves.toBeTruthy(),
+        expect(fileExists(fontFile)).resolves.toBeTruthy(),
+        expect(fileExists(deepFile)).resolves.toBeTruthy(),
+        expect(fileExists(cssFile)).resolves.toBeTruthy(),
+        expect(fileExists(cssFont)).resolves.toBeTruthy()
+      ])
+    )
+    .then(Promise.all([
+      rimrafp(outputFile),
+      rimrafp(imageFile),
+      rimrafp(fontFile),
       rimrafp(deepFile),
       rimrafp(cssFile),
       rimrafp(cssFont)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-rebase",
-  "version": "0.11.3",
+  "version": "0.11.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ import rebasePlugin from "rollup-plugin-rebase"
 
 const input = "./src/index.js"
 const outputFolder = "./lib";
-const rebase = rebasePlugin({ outputFolder })
+const rebase = rebasePlugin({ outputFolder, input })
 
 rollup({
   input: input,
@@ -73,6 +73,13 @@ rollup({
 )
 ```
 
+### Options
+* input (required): The location of your entry point for rollup
+* outputFolder (required): The location that assets will be written to
+* prependName: If true, generated filenames will be ORIGINALFILENAME_HASH instead of just HASH
+* verbose: If true, increases log level
+* include: Standard include option for rollup plugins. Supports a minimatch string.
+* exlude: Standard exclude option for rollup plugins. Supports a minimatch string.
 
 
 ## Copyright


### PR DESCRIPTION
I think it'd be easier to work with filenames that have the hash appended to them rather than replacing them. So instead of abc123.png, it'll be blah_abc123.png

I left it behind an option to not force the behavior on everyone, but I think it'd be nicer to use overall.

This depends on https://github.com/sebastian-software/postcss-smart-asset/pull/1 in postcss-smart-asset to correctly append hashes to the filenames specified in css