### PR TITLE
allow output path that is not the root

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -24,6 +24,18 @@ export default assets;
 "
 `;
 
+exports[`Assets written to subfolder 1`] = `
+"import _fXQovA from './img/fXQovA.woff';
+import _XDOPW from './img/XDOPW.png';
+import _dnIKKh from './img/dnIKKh.gif';
+import _iQCqkl from './img/iQCqkl.css';
+
+var assets = \`\${_fXQovA}|\${_XDOPW}|\${_dnIKKh}|\${_iQCqkl}\`;
+
+export default assets;
+"
+`;
+
 exports[`Mixed Assets 1`] = `
 "import _fXQovA from './fXQovA.woff';
 import _dBNImC from './dBNImC.svg';

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -81,6 +81,41 @@ test("Assets", () => {
     ]))
 })
 
+test("Assets written to subfolder", () => {
+  var outputFile = `${outputFolder}/assets-subfolder/index.js`
+
+  var imageFile = `${outputFolder}/assets-subfolder/img/XDOPW.png`
+  var fontFile = `${outputFolder}/assets-subfolder/img/fXQovA.woff`
+  var deepFile = `${outputFolder}/assets-subfolder/img/dnIKKh.gif`
+  var cssFile = `${outputFolder}/assets-subfolder/img/iQCqkl.css`
+  var cssFont = `${outputFolder}/assets-subfolder/img/gadyfD.woff`
+
+  var options = {outputFolder: `${outputFolder}assets-subfolder/img/`, outputBase: dirname(outputFile)}
+
+  return bundle("./__tests__/fixtures/assets.js", outputFile, options)
+    .then(() =>
+      Promise.all([
+        expect(fileExists(outputFile)).resolves.toBeTruthy(),
+        readFile(outputFile, "utf-8").then((content) => {
+          expect(content).toMatchSnapshot()
+        }),
+        expect(fileExists(imageFile)).resolves.toBeTruthy(),
+        expect(fileExists(fontFile)).resolves.toBeTruthy(),
+        expect(fileExists(deepFile)).resolves.toBeTruthy(),
+        expect(fileExists(cssFile)).resolves.toBeTruthy(),
+        expect(fileExists(cssFont)).resolves.toBeTruthy()
+      ])
+    )
+    .then(Promise.all([
+      rimrafp(outputFile),
+      rimrafp(imageFile),
+      rimrafp(fontFile),
+      rimrafp(deepFile),
+      rimrafp(cssFile),
+      rimrafp(cssFont)
+    ]))
+})
+
 test("Outside Assets", () => {
   var outputFile = `${outputFolder}/outside/index.js`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-rebase",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ rollup({
 ### Options
 * input (required): The location of your entry point for rollup
 * outputFolder (required): The location that assets will be written to
+* outputBase: The main rollup output folder. Defaults to outputFolder if not set.
 * prependName: If true, generated filenames will be ORIGINALFILENAME_HASH instead of just HASH
 * verbose: If true, increases log level
 * include: Standard include option for rollup plugins. Supports a minimatch string.

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ const externalIds = {}
 const defaultExclude = [ "**/*.json", "**/*.mjs", "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue" ]
 
 export default function rebase(options = {}) {
-  const { include, exclude = defaultExclude, input, outputFolder, verbose, prependName } = options
+  const { include, exclude = defaultExclude, input, outputFolder, outputBase, verbose, prependName } = options
   const filter = createFilter(include, exclude)
 
   return {
@@ -104,16 +104,20 @@ export default function rebase(options = {}) {
 
           var inputFolder = path.dirname(path.resolve(input))
           var relativeToRoot = path.relative(path.dirname(fileSource), inputFolder).replace(/\\/g, "/")
+          var relativeOutputPath = path.relative(outputBase || outputFolder, outputFolder);
+          if(relativeOutputPath){
+            relativeOutputPath += '/';
+          }
 
           // Adjust destId so that it points to the root folder - from any
           // depth we detected inside the original project structure.
           var importId
           if (relativeToRoot.charAt(0) === ".") {
-            importId = `${relativeToRoot}/${destFilename}`
+            importId = `${relativeToRoot}/${relativeOutputPath}${destFilename}`
           } else if (relativeToRoot === "") {
-            importId = `./${destFilename}`
+            importId = `./${relativeOutputPath}${destFilename}`
           } else {
-            importId = `./${relativeToRoot}/${destFilename}`
+            importId = `./${relativeToRoot}/${relativeOutputPath}${destFilename}`
           }
 
           if (fileExt in styleParser) {


### PR DESCRIPTION
addresses #8 in a backwards compatible way. 

There was no way without a new option to see the relative path from the root output folder to your image output folder. So the easiest thing was to add a second option, but default its value to the value of outputFolder for the common case where you want everything at the root.

This should not affect anyone who is currently using rebase since it only makes a difference if you add in the outputBase option.