### PR TITLE
Fixed error when used with code splitting feature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,8 +142,8 @@ export default function rebase(options = {}) {
       return null
     },
 
-    async generateBundle({ file }) {
-      const outputFolder = path.dirname(file)
+    async generateBundle({ file, dir }) {
+      const outputFolder = dir || path.dirname(file)
 
       try {
         // Copy all assets in parallel and waiting for it to complete.


### PR DESCRIPTION
Hi,
I'm using this plugin in a project using the new code splitting feature, this edit fix a problem I encountered without breaking anything.

It update to the new rollup hooks and check if we are building using a target directory or file.